### PR TITLE
Reject names with null-bytes in NamedLock::create.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,10 @@ impl NamedLock {
         // so we block the `/` character.
         //
         // On Windows `\` character is invalid.
-        if name.contains('/') || name.contains('\\') {
+        //
+        // Both platforms expect null-terminated strings,
+        // so we block null-bytes.
+        if name.chars().any(|c| matches!(c, '\0' | '/' | '\\')) {
             return Err(Error::InvalidCharacter);
         }
 


### PR DESCRIPTION
Currently it is possible to produce a panic on Windows with the following:

```rust
NamedLock::create("\0 foo");
```

(notice no `.unwrap()` is required)

There is also inconsistent behavior between platforms. On Windows the name `"\0"` is treated equivalent to an empty string, but on Unix `""` is just fine while `"\0"` results in `Err(Error::CreateFailed)`.

The simplest fix I can think of is to reject null-bytes altogether, in addition to `\` and `/`. I think this is technically a breaking change, but a minor one.