### PR TITLE
Migrate to windows-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ thiserror = "1.0.35"
 libc = "0.2.132"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["handleapi", "synchapi", "winbase", "winnt", "winerror"] }
-widestring = "1.0.2"
+windows = { version = "0.53", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading"] }
 
 [dev-dependencies]
 static_assertions = "1.1.0"


### PR DESCRIPTION
- Migrate to windows-rs. There is also -sys crate which would be identical to what winapi used to provide, windows-rs on the other side wraps winapi errors into `Error` convertible to `std::io::Error` which I found really nice. Lotta sys calls also return `Result`. Since many types in `windows-rs` are guarded with feature flags, you may find a type-to-feature explorer quite useful: https://microsoft.github.io/windows-rs/features/#/master
- Drop `widestring` as `windows-rs` facilities provide tools for working with strings on Windows, typically via `HSTRING` which implements a variety of `From` traits which then is easily convertible into `PCWSTR` and alike.

Fixes https://github.com/oblique/named-lock/issues/7